### PR TITLE
[WIP] When a record is deleted it should use unscoped association calls

### DIFF
--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -77,7 +77,7 @@ module ZombieRecord
           when :has_one, :belongs_to
             (klass || association.klass).unscoped { super() }
           when :has_many
-            super().deleted
+            super().with_deleted
           end
         else
           super()

--- a/spec/restorable_spec.rb
+++ b/spec/restorable_spec.rb
@@ -124,16 +124,46 @@ describe ZombieRecord::Restorable do
   end
 
   describe "#associate_with_deleted" do
-    it "removes default scope from associations when deleted" do
-      cover = Cover.create!
-      book = Book.create!(cover: cover)
+    it "allows accessing a deleted has_one association" do
+      book = Book.create!
+      cover = Cover.create!(book: book)
 
       book.destroy
-      Book.find_by_id(book.id).should be_nil
-      Cover.find_by_id(cover.id).should be_nil
+      book = Book.deleted.find(book.id)
 
-      book = Book.deleted.first
-      book.cover.should == cover
+      book.cover.should == cover.reload
+    end
+
+    it "allows accessing deleted belongs_to associations" do
+      book = Book.create!
+      chapter = book.chapters.create!
+
+      book.destroy
+      chapter = Chapter.deleted.find(chapter.id)
+
+      chapter.book.should == book
+    end
+
+    it "ensures deleted associations themselves allow access to deleted records" do
+      book = Book.create!
+      chapter = book.chapters.create!
+      bookmark = book.bookmarks.create!
+
+      book.destroy
+      bookmark = Bookmark.deleted.find(bookmark.id)
+
+      bookmark.book.chapters.should == [chapter]
+      chapter = bookmark.book.chapters.first
+
+      chapter.book.should == book
+    end
+
+    it "forwards normal method calls" do
+      book = Book.create!(title: "The Odyssey")
+      book.destroy
+      book = Book.deleted.find(book.id)
+
+      book.title.should == "The Odyssey"
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -80,6 +80,7 @@ RSpec.configure do |config|
         t.integer :author_id
         t.integer :library_id
         t.timestamps
+        t.string :title
         t.timestamp :deleted_at
       end
 


### PR DESCRIPTION
@libo @dasch @bquorning @pdeuter 

I think this addition is useful, for example, you can retrieve a deleted category, and gracefully get the default_translation without having to do something like this:

```
>> DC::Content.with_deleted { DC::Translation.with_deleted { category.default_translation.title } }
  DC::Content Load (0.2ms)  SELECT `dc_contents`.* FROM `dc_contents` WHERE `dc_contents`.`source_id` = 10017 AND `dc_contents`.`source_type` = 'Category' LIMIT 1
  DC::Translation Load (0.3ms)  SELECT `dc_translations`.* FROM `dc_translations` WHERE `dc_translations`.`id` = 10112 LIMIT 1
=> "Using Help Center"
```

Instead we can simply do:

```
>> category.default_translation.title
  DC::Content Load (0.2ms)  SELECT `dc_contents`.* FROM `dc_contents` WHERE `dc_contents`.`source_id` = 10017 AND `dc_contents`.`source_type` = 'Category' LIMIT 1
  DC::Translation Load (0.3ms)  SELECT `dc_translations`.* FROM `dc_translations` WHERE `dc_translations`.`id` = 10112 LIMIT 1
=> "Using Help Center"
```

The thing I'm having trouble with is the timing of redefining the association methods. If I do a class_eval at the time the module is included it doesn't work because it seems like Rails is redefining the has_many associations after I initially redefine them. The only solution I came up with for that was overriding the methods in an after_initialize callback, and simply marking which classes were overridden so we don't do it twice.

What do you guys think?
