### PR TITLE
Perform a single update when updated_at is present

### DIFF
--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -54,11 +54,13 @@ module ZombieRecord
     # Override Rails' #destroy_row for soft-delete functionality
     def destroy_row
       time = current_time_from_proper_timezone
-      update_column(:deleted_at, time)
 
+      update_params = { deleted_at: time }
       if self.class.column_names.include?("updated_at")
-        update_column(:updated_at, time)
+        update_params[:updated_at] = time
       end
+
+      update_columns(update_params)
     end
 
     def restore_associated_records!


### PR DESCRIPTION
When the `updated_at` attribute is present we fire two separate queries.
One for `updated_at` and the other for `deleted_at`.

This PR consolidates them into one.

@bastien @bquorning 