### PR TITLE
Fix counter_cache behavior for Rails 4.2

### DIFF
--- a/lib/zombie_record.rb
+++ b/lib/zombie_record.rb
@@ -5,3 +5,25 @@ module ZombieRecord
 end
 
 require 'zombie_record/restorable'
+
+module ActiveRecord
+  module Persistence
+    alias_method :zombie_record_alias_destroy_row, :destroy_row
+
+    # Maybe override Rails' #destroy_row for soft-delete functionality
+    def destroy_row
+      if self.class.include?(ZombieRecord::Restorable)
+        time = current_time_from_proper_timezone
+
+        update_params = { deleted_at: time }
+        if self.class.column_names.include?("updated_at")
+          update_params[:updated_at] = time
+        end
+
+        update_columns(update_params) ? 1 : 0
+      else
+        zombie_record_alias_destroy_row
+      end
+    end
+  end
+end

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -51,18 +51,6 @@ module ZombieRecord
 
     private
 
-    # Override Rails' #destroy_row for soft-delete functionality
-    def destroy_row
-      time = current_time_from_proper_timezone
-
-      update_params = { deleted_at: time }
-      if self.class.column_names.include?("updated_at")
-        update_params[:updated_at] = time
-      end
-
-      update_columns(update_params)
-    end
-
     def restore_associated_records!
       self.class.reflect_on_all_associations.each do |association|
         # Only restore associations that are automatically destroyed alongside

--- a/spec/restorable_spec.rb
+++ b/spec/restorable_spec.rb
@@ -91,6 +91,17 @@ describe ZombieRecord::Restorable do
       bookmark = Timecop.travel(2.days.ago) { Bookmark.create! }
       expect { bookmark.destroy }.to_not raise_exception
     end
+
+    it "updates the counter cache" do
+      book = Book.create!
+      bookmark = book.bookmarks.create!
+
+      expect(book.reload.bookmarks_count).to eq(1)
+
+      bookmark.destroy!
+
+      expect(book.reload.bookmarks_count).to eq(0)
+    end
   end
 
   describe "#restore!" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -27,7 +27,7 @@ end
 class Bookmark < ActiveRecord::Base
   include ZombieRecord::Restorable
 
-  belongs_to :book
+  belongs_to :book, counter_cache: true
 end
 
 class Note < ActiveRecord::Base
@@ -85,6 +85,7 @@ RSpec.configure do |config|
       create_table :books do |t|
         t.integer :author_id
         t.integer :library_id
+        t.integer :bookmarks_count
         t.timestamps null: false
         t.string :title
         t.timestamp :deleted_at


### PR DESCRIPTION
Previously we have just overridden the behavior of `ActiveRecord::Persistence#destroy_row` to apply soft-delete functionality. This does not work, since Rails depends on inheritance to add extra functionality to `#destroy_row`. In Rails 4.2, this includes `ActiveRecord::CounterCache#destroy_row` calling `super`, as well as `ActiveRecord::Locking::Optimistic#destroy_row` also calling `super`.

See also

https://github.com/rails/rails/pull/14735
https://github.com/rails/rails/pull/14765