### PR TITLE
Allow disabling Zombie Record

### DIFF
--- a/lib/zombie_record.rb
+++ b/lib/zombie_record.rb
@@ -2,6 +2,15 @@ require 'active_support'
 require 'zombie_record/version'
 
 module ZombieRecord
+  @@enabled = true
+
+  def self.enabled?
+    @@enabled
+  end
+
+  def self.enabled=(enabled)
+    @@enabled = enabled
+  end
 end
 
 require 'zombie_record/restorable'
@@ -12,7 +21,7 @@ module ActiveRecord
 
     # Maybe override Rails' #destroy_row for soft-delete functionality
     def destroy_row
-      if self.class.include?(ZombieRecord::Restorable)
+      if self.class.include?(ZombieRecord::Restorable) && ZombieRecord.enabled?
         time = current_time_from_proper_timezone
 
         update_params = { deleted_at: time }

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -3,7 +3,7 @@ module ZombieRecord
     extend ActiveSupport::Concern
 
     included do
-      default_scope { where(deleted_at: nil) }
+      default_scope { ZombieRecord.enabled? ? where(deleted_at: nil) : all }
 
       define_callbacks :restore
     end


### PR DESCRIPTION
Allows disabling Zombie Record at runtime. When disabled, deleted records will not be filtered out of queries and everything will be hard deleted.