### PR TITLE
Fix to_a vs records

### DIFF
--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: "../"
 
-gem "activerecord", "~> 5.0.0.beta1"
+gem "activerecord", "~> 5.0.0.beta3"

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -8,29 +8,23 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (5.0.0.beta1)
-      activesupport (= 5.0.0.beta1)
-      builder (~> 3.1)
-    activerecord (5.0.0.beta1)
-      activemodel (= 5.0.0.beta1)
-      activesupport (= 5.0.0.beta1)
+    activemodel (5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
+    activerecord (5.0.0.beta3)
+      activemodel (= 5.0.0.beta3)
+      activesupport (= 5.0.0.beta3)
       arel (~> 7.0)
-    activesupport (5.0.0.beta1)
+    activesupport (5.0.0.beta3)
       concurrent-ruby (~> 1.0)
       i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      method_source
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (7.0.0)
-    builder (3.2.2)
     byebug (8.2.1)
-    concurrent-ruby (1.0.0)
+    concurrent-ruby (1.0.1)
     diff-lcs (1.2.5)
     i18n (0.7.0)
-    json (1.8.3)
-    method_source (0.8.2)
-    minitest (5.8.3)
+    minitest (5.8.4)
     mysql2 (0.4.2)
     rake (10.4.2)
     rspec (2.14.1)
@@ -51,7 +45,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord (~> 5.0.0.beta1)
+  activerecord (~> 5.0.0.beta3)
   bundler (~> 1.3)
   byebug
   rake

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -148,8 +148,14 @@ module ZombieRecord
     end
 
     module WithDeletedAssociationsWrapper
-      def to_a
-        super.map(&:with_deleted_associations)
+      if ActiveRecord::VERSION::MAJOR < 5
+        def to_a
+          super.map(&:with_deleted_associations)
+        end
+      else
+        def records
+          super.map(&:with_deleted_associations)
+        end
       end
     end
 


### PR DESCRIPTION
Rails 5 uses `records` where earlier versions used `to_a`.

cc @dasch @pschambacher @codella 