### PR TITLE
Fix bug on Ruby 2.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 rvm:
   - 2.1.8
   - 2.2.4
+  - 2.3.0
 gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -96,6 +96,10 @@ module ZombieRecord
         delegate_to_record(name) { @record.public_send(name, *args, &block) }
       end
 
+      def respond_to_missing?(method, include_all = false)
+        @record.respond_to?(method, include_all)
+      end
+
       # We want *all* methods to be delegated.
       BasicObject.instance_methods.each do |name|
         define_method(name) do |*args, &block|


### PR DESCRIPTION
In Ruby 2.3.0, `BasicObject` apparently cannot implement `method_missing` without also implementing `respond_to_missing?`.

I haven’t been able to write a failing spec for it :-/

See also the article [Always Define `respond_to_missing?` When Overriding `method_missing`](https://robots.thoughtbot.com/always-define-respond-to-missing-when-overriding).

cc @dasch @codella 