### PR TITLE
Allow calling private methods on Restorable

### DIFF
--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -93,7 +93,7 @@ module ZombieRecord
       end
 
       def method_missing(name, *args, &block)
-        delegate_to_record(name) { @record.public_send(name, *args, &block) }
+        delegate_to_record(name) { @record.send(name, *args, &block) }
       end
 
       def respond_to_missing?(method, include_all = false)

--- a/spec/restorable_spec.rb
+++ b/spec/restorable_spec.rb
@@ -53,6 +53,14 @@ RSpec.describe ZombieRecord::Restorable do
 
       expect(book.title).to eq("The Odyssey")
     end
+
+    it "forwards private method calls" do
+      book = Book.create!(title: "The Odyssey")
+      book.destroy
+      book = Book.with_deleted.first
+
+      expect(book.to_ary).to be_nil
+    end
   end
 
   describe ".deleted" do


### PR DESCRIPTION
I needed this when testing upgrading a Rails 5 application from Ruby 2.4 to Ruby 2.5. I didn’t manage to figure out why – yet.