### PR TITLE
Conditional respond_to_missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ rvm:
   - 2.2
   - 2.3
   - 2.4
+  - 2.5
 gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
@@ -14,4 +15,6 @@ script: "bundle exec rake spec"
 matrix:
   exclude:
     - rvm: 2.4
+      gemfile: gemfiles/rails4.1.gemfile
+    - rvm: 2.5
       gemfile: gemfiles/rails4.1.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1
   - 2.2
   - 2.3
   - 2.4
@@ -14,11 +13,5 @@ bundler_args: ""
 script: "bundle exec rake spec"
 matrix:
   exclude:
-    - rvm: 2.1
-      gemfile: gemfiles/rails5.0.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails5.1.gemfile
-    - rvm: 2.1
-      gemfile: gemfiles/rails5.2.gemfile
     - rvm: 2.4
       gemfile: gemfiles/rails4.1.gemfile

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -96,8 +96,10 @@ module ZombieRecord
         delegate_to_record(name) { @record.public_send(name, *args, &block) }
       end
 
-      def respond_to_missing?(method, include_all = false)
-        @record.respond_to?(method, include_all)
+      if ::RUBY_VERSION.start_with?('2.3.')
+        def respond_to_missing?(method, include_all = false)
+          @record.respond_to?(method, include_all)
+        end
       end
 
       # We want *all* methods to be delegated.

--- a/spec/restorable_spec.rb
+++ b/spec/restorable_spec.rb
@@ -53,6 +53,15 @@ RSpec.describe ZombieRecord::Restorable do
 
       expect(book.title).to eq("The Odyssey")
     end
+
+    it "forwards to_ary" do
+      book = Book.create!(title: "The Odyssey")
+      book.destroy
+      book = Book.with_deleted.first
+
+      # #flatten will implicitly call #to_ary
+      expect([[[book]]].flatten).to eq([book])
+    end
   end
 
   describe ".deleted" do


### PR DESCRIPTION
The implicit `#flatten` -> `#to_ary` calls didn’t work with Ruby 2.5. 

Ex. `[[[42]]].flatten` will implicitly call `#to_ary` on 42, and it will also call either `respond_to?` or `respond_to_missing?` first. It seems that the implementation of `respond_to_missing?` was only really necessary for Ruby 2.3.