### PR TITLE
Bump for Rails 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,19 +4,29 @@ rvm:
   - 2.3
   - 2.4
   - 2.5
+  - 2.6
 gemfile:
   - gemfiles/rails4.1.gemfile
   - gemfiles/rails4.2.gemfile
   - gemfiles/rails5.0.gemfile
   - gemfiles/rails5.1.gemfile
   - gemfiles/rails5.2.gemfile
+  - gemfiles/rails6.0.gemfile
 bundler_args: ""
 script: "bundle exec rake spec"
 matrix:
   exclude:
+    - rvm: 2.2
+      gemfile: gemfiles/rails6.0.gemfile
+    - rvm: 2.3
+      gemfile: gemfiles/rails6.0.gemfile
     - rvm: 2.4
       gemfile: gemfiles/rails4.1.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails6.0.gemfile
     - rvm: 2.5
+      gemfile: gemfiles/rails4.1.gemfile
+    - rvm: 2.6
       gemfile: gemfiles/rails4.1.gemfile
 services:
    - mysql

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: "../"
+
+gem "activerecord", "~> 6.0"

--- a/zombie_record.gemspec
+++ b/zombie_record.gemspec
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "activerecord", ">= 4.1", "< 6.0"
+  spec.add_dependency "activerecord", ">= 4.1", "< 6.1"
   spec.add_dependency "mysql2"
 
-  spec.add_development_dependency "bundler", "~> 1.3"
+  spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bump"


### PR DESCRIPTION
 - Added Ruby 2.6 to Travis matrix
 - Excluded Rails 6 with Ruby 2.4, Rails 6 requires >= Ruby 2.5
 - Removed bundler version requirement.
 - Update gemspec to allow Rails 6