### PR TITLE
Add mysql as service in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,5 @@ matrix:
       gemfile: gemfiles/rails4.1.gemfile
     - rvm: 2.5
       gemfile: gemfiles/rails4.1.gemfile
+services:
+   - mysql


### PR DESCRIPTION
Travis has changed a fair bit since we ran the build last. Builds use the Ubuntu [xenial distribution](https://changelog.travis-ci.com/ubuntu-xenial-16-04-build-environment-is-here!-79690) by default and for the services to start, [you need to specify them](https://docs.travis-ci.com/user/database-setup/#starting-services).
