### PR TITLE
Use SQLite when running tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,18 +6,6 @@ jobs:
   specs:
     runs-on: ubuntu-latest
 
-    services:
-      mysql:
-        image: mysql:5.7
-        ports:
-          - 3306:3306
-        env:
-          MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
-        options: >-
-          --health-cmd "mysqladmin ping -h localhost"
-          --health-interval 5s
-          --health-timeout 3s
-
     strategy:
       matrix:
         ruby-version:

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -3,4 +3,4 @@ source 'https://rubygems.org'
 gemspec path: "../"
 
 gem "activerecord", "~> 4.2.0"
-gem "mysql2", "~> 0.4.0"
+gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/rails4.2.gemfile.lock
+++ b/gemfiles/rails4.2.gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     zombie_record (1.4.3)
       activerecord (>= 4.2, < 6.2)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -29,7 +28,6 @@ GEM
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    mysql2 (0.4.10)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -44,6 +42,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     timecop (0.9.2)
     tzinfo (1.2.9)
@@ -58,9 +57,9 @@ DEPENDENCIES
   bump
   bundler
   byebug
-  mysql2 (~> 0.4.0)
   rake
   rspec (~> 3.5)
+  sqlite3 (~> 1.3.6)
   timecop
   zombie_record!
 

--- a/gemfiles/rails5.0.gemfile
+++ b/gemfiles/rails5.0.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: "../"
 
 gem "activerecord", "~> 5.0.0"
+gem 'sqlite3', '~> 1.3.6'

--- a/gemfiles/rails5.0.gemfile.lock
+++ b/gemfiles/rails5.0.gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     zombie_record (1.4.3)
       activerecord (>= 4.2, < 6.2)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +26,6 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    mysql2 (0.5.3)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -42,6 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     timecop (0.9.2)
     tzinfo (1.2.9)
@@ -58,6 +57,7 @@ DEPENDENCIES
   byebug
   rake
   rspec (~> 3.5)
+  sqlite3 (~> 1.3.6)
   timecop
   zombie_record!
 

--- a/gemfiles/rails5.1.gemfile
+++ b/gemfiles/rails5.1.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: "../"
 
 gem "activerecord", "~> 5.1.0"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"

--- a/gemfiles/rails5.1.gemfile.lock
+++ b/gemfiles/rails5.1.gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     zombie_record (1.4.3)
       activerecord (>= 4.2, < 6.2)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +26,6 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    mysql2 (0.5.3)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -42,6 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     timecop (0.9.2)
     tzinfo (1.2.9)
@@ -58,6 +57,7 @@ DEPENDENCIES
   byebug
   rake
   rspec (~> 3.5)
+  sqlite3 (~> 1.3, >= 1.3.6)
   timecop
   zombie_record!
 

--- a/gemfiles/rails5.2.gemfile
+++ b/gemfiles/rails5.2.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: "../"
 
 gem "activerecord", "~> 5.2.0"
+gem "sqlite3", "~> 1.3", ">= 1.3.6"

--- a/gemfiles/rails5.2.gemfile.lock
+++ b/gemfiles/rails5.2.gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     zombie_record (1.4.3)
       activerecord (>= 4.2, < 6.2)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -27,7 +26,6 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    mysql2 (0.5.3)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -42,6 +40,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     timecop (0.9.2)
     tzinfo (1.2.9)
@@ -58,6 +57,7 @@ DEPENDENCIES
   byebug
   rake
   rspec (~> 3.5)
+  sqlite3 (~> 1.3, >= 1.3.6)
   timecop
   zombie_record!
 

--- a/gemfiles/rails6.0.gemfile
+++ b/gemfiles/rails6.0.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: "../"
 
 gem "activerecord", "~> 6.0.0"
+gem "sqlite3", "~> 1.4"

--- a/gemfiles/rails6.0.gemfile.lock
+++ b/gemfiles/rails6.0.gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     zombie_record (1.4.3)
       activerecord (>= 4.2, < 6.2)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -26,7 +25,6 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    mysql2 (0.5.3)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -41,6 +39,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    sqlite3 (1.4.2)
     thread_safe (0.3.6)
     timecop (0.9.2)
     tzinfo (1.2.9)
@@ -58,6 +57,7 @@ DEPENDENCIES
   byebug
   rake
   rspec (~> 3.5)
+  sqlite3 (~> 1.4)
   timecop
   zombie_record!
 

--- a/gemfiles/rails6.1.gemfile
+++ b/gemfiles/rails6.1.gemfile
@@ -3,3 +3,4 @@ source 'https://rubygems.org'
 gemspec path: "../"
 
 gem "activerecord", "~> 6.1.0"
+gem "sqlite3", "~> 1.4"

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -3,7 +3,6 @@ PATH
   specs:
     zombie_record (1.4.3)
       activerecord (>= 4.2, < 6.2)
-      mysql2
 
 GEM
   remote: https://rubygems.org/
@@ -26,7 +25,6 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     minitest (5.14.2)
-    mysql2 (0.5.3)
     rake (13.0.3)
     rspec (3.10.0)
       rspec-core (~> 3.10.0)
@@ -41,6 +39,7 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.10.0)
     rspec-support (3.10.1)
+    sqlite3 (1.4.2)
     timecop (0.9.2)
     tzinfo (2.0.4)
       concurrent-ruby (~> 1.0)
@@ -57,6 +56,7 @@ DEPENDENCIES
   byebug
   rake
   rspec (~> 3.5)
+  sqlite3 (~> 1.4)
   timecop
   zombie_record!
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -70,18 +70,10 @@ RSpec.configure do |config|
   end
 
   config.before :suite do
-    mysql = URI(ENV['MYSQL_URL'] || 'mysql://root@127.0.0.1:3306')
-
     ActiveRecord::Base.establish_connection(
-      adapter: "mysql2",
-      username: mysql.user,
-      host: mysql.host,
-      port: mysql.port,
-      password: mysql.password
+      adapter: "sqlite3",
+      database: ":memory:"
     )
-
-    ActiveRecord::Base.connection.create_database("zombie_record", charset: "utf8mb4")
-    ActiveRecord::Base.connection.execute("use zombie_record;")
 
     ActiveRecord::Schema.define do
       self.verbose = false

--- a/zombie_record.gemspec
+++ b/zombie_record.gemspec
@@ -18,12 +18,12 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = ">= 2.4"
 
   spec.add_dependency "activerecord", ">= 4.2", "< 6.2"
-  spec.add_dependency "mysql2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "bump"
   spec.add_development_dependency "rspec", "~> 3.5"
+  spec.add_development_dependency "sqlite3"
   spec.add_development_dependency "timecop"
 end


### PR DESCRIPTION
This gem is not MySQL specific, so how about we run the tests against an in-memory SQLite database and cut the CI time by 50%? Sounds good to me.