### PR TITLE
Drop support for Rails versions before 5.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,6 @@ jobs:
           - 2.5
           - 2.6
         gemfile:
-          - rails4.2
           - rails5.0
           - rails5.1
           - rails5.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ###### Unreleased
 
+* Drop support for Rails 4.2.
+
 ###### v1.4.3
 
 * Drop support for Ruby 2.2 and 2.3.

--- a/gemfiles/rails4.2.gemfile
+++ b/gemfiles/rails4.2.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: "../"
-
-gem "activerecord", "~> 4.2.0"
-gem 'sqlite3', '~> 1.3.6'

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -148,14 +148,8 @@ module ZombieRecord
     end
 
     module WithDeletedAssociationsWrapper
-      if ActiveRecord::VERSION::MAJOR < 5
-        def to_a
-          super.map(&:with_deleted_associations)
-        end
-      else
-        def records
-          super.map(&:with_deleted_associations)
-        end
+      def records
+        super.map(&:with_deleted_associations)
       end
     end
 

--- a/zombie_record.gemspec
+++ b/zombie_record.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = ">= 2.4"
 
-  spec.add_dependency "activerecord", ">= 4.2", "< 6.2"
+  spec.add_dependency "activerecord", ">= 5.0", "< 6.2"
 
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "byebug"


### PR DESCRIPTION
Rails 4.2 is old and we can remove code by not supporting it anymore.