### PR TITLE
Drop Ruby 2.4 & 2.5 and cleanup CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,6 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - 2.4
-          - 2.5
           - 2.6
         gemfile:
           - rails5.0
@@ -18,11 +16,6 @@ jobs:
           - rails5.2
           - rails6.0
           - rails6.1
-        exclude:
-          - ruby-version: 2.4
-            gemfile: rails6.0
-          - ruby-version: 2.4
-            gemfile: rails6.1
     env:
       BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
     steps:
@@ -34,3 +27,18 @@ jobs:
           bundler-cache: true
       - name: RSpec
         run: bundle exec rspec
+
+  specs_successful:
+    name: Specs passing?
+    needs: specs
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          if ${{ needs.specs.result == 'success' }}
+          then
+            echo "All specs pass"
+          else
+            echo "Some specs failed"
+            false
+          fi

--- a/zombie_record.gemspec
+++ b/zombie_record.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.4"
+  spec.required_ruby_version = ">= 2.6"
 
   spec.add_dependency "activerecord", ">= 5.0", "< 6.2"
 


### PR DESCRIPTION
We should really only be using Ruby 2.7+ but we'll keep 2.6 for now.

Configuring GitHub to have many required tests is hard to maintain.

In fact, the admin needs to duplicate what is defined in the actions.yml test matrix. It should be quite a bit easier this way, just having one CI job that depends on the success of the entire test matrix.