### PR TITLE
Release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,11 @@
 ###### Unreleased
 
+###### v1.5.0
+
 * Add support for Rails 7.0
-* Drop support for Rails 4.2.
+* Add support for Ruby 2.7, 3.0, & 3.1
+* Drop support for Ruby 2.4 & 2.5
+* Drop support for Rails 4.2
 
 ###### v1.4.3
 

--- a/lib/zombie_record/version.rb
+++ b/lib/zombie_record/version.rb
@@ -1,3 +1,3 @@
 module ZombieRecord
-  VERSION = "1.4.3"
+  VERSION = "1.5.0"
 end


### PR DESCRIPTION
- Adds support for Ruby 2.7, 3.0, & 3.1 #37
- Adds support for Rails 7.0 #36
- Drops support for Ruby 2.4 & 2.5 #35
- Drops support for Rails 4.2 #33