### PR TITLE
Fix for ruby 3 incompatibility

### DIFF
--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -96,6 +96,8 @@ module ZombieRecord
         delegate_to_record(name) { @record.public_send(name, *args, &block) }
       end
 
+      ruby2_keywords :method_missing if respond_to?(:ruby2_keywords, true)
+
       # We want *all* methods to be delegated.
       BasicObject.instance_methods.each do |name|
         define_method(name) do |*args, &block|

--- a/spec/restorable_spec.rb
+++ b/spec/restorable_spec.rb
@@ -62,6 +62,15 @@ RSpec.describe ZombieRecord::Restorable do
       # #flatten will implicitly call #to_ary
       expect([[[book]]].flatten).to eq([book])
     end
+
+    it "doesn't re-save duplicated record" do
+      book = Book.create!(title: "The Odyssey")
+      book.destroy
+      book_dup = Book.with_deleted.first.save(validate: true)
+
+      expect(Book.count).to eq(0)
+      expect(Book.with_deleted.size).to eq(1)
+    end
   end
 
   describe ".deleted" do


### PR DESCRIPTION
This spec demonstrates the code path where we get argument errors seen when adding ruby 3 on HC with Zombie records. Since we need support for ruby 2.6+, `ruby2_keywords` is the only correct way to do it, read more [here](https://eregon.me/blog/2021/02/13/correct-delegation-in-ruby-2-27-3.html).