### PR TITLE
Release v1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ###### Unreleased
 
+###### v1.8.0
+
 * Drop upper limit on Rails, test with Rails main.
 * Drop support for Rails < 6.0.
 * Drop support for Ruby 2.7 & 3.0.

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.7.0)
+    zombie_record (1.8.0)
       activerecord (>= 6.1)
 
 GEM

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.7.0)
+    zombie_record (1.8.0)
       activerecord (>= 6.1)
 
 GEM

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.7.0)
+    zombie_record (1.8.0)
       activerecord (>= 6.1)
 
 GEM

--- a/lib/zombie_record/version.rb
+++ b/lib/zombie_record/version.rb
@@ -1,3 +1,3 @@
 module ZombieRecord
-  VERSION = "1.7.0"
+  VERSION = "1.8.0"
 end


### PR DESCRIPTION
 * Drop upper limit on Rails, test with Rails main.
 * Drop support for Rails < 6.0.
 * Drop support for Ruby 2.7 & 3.0.