### PR TITLE
Stop delegating unsafe methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ###### Unreleased
 
+* Don't delegate `:__id__` and `:__send__` to the deleted record object.
+
 ###### v1.8.0
 
 * Drop upper limit on Rails, test with Rails main.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ###### Unreleased
 
+###### v1.9.0
+
 * Don't delegate `:__id__` and `:__send__` to the deleted record object.
 
 ###### v1.8.0

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,6 @@
 require "bundler/gem_tasks"
+require "rspec/core/rake_task"
+
+RSpec::Core::RakeTask.new(:spec)
+
+task default: :spec

--- a/gemfiles/rails6.1.gemfile.lock
+++ b/gemfiles/rails6.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.8.0)
+    zombie_record (1.9.0)
       activerecord (>= 6.1)
 
 GEM

--- a/gemfiles/rails7.0.gemfile.lock
+++ b/gemfiles/rails7.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.8.0)
+    zombie_record (1.9.0)
       activerecord (>= 6.1)
 
 GEM

--- a/gemfiles/rails7.1.gemfile.lock
+++ b/gemfiles/rails7.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.8.0)
+    zombie_record (1.9.0)
       activerecord (>= 6.1)
 
 GEM

--- a/gemfiles/rails7.2.gemfile.lock
+++ b/gemfiles/rails7.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.8.0)
+    zombie_record (1.9.0)
       activerecord (>= 6.1)
 
 GEM

--- a/gemfiles/rails8.0.gemfile.lock
+++ b/gemfiles/rails8.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    zombie_record (1.8.0)
+    zombie_record (1.9.0)
       activerecord (>= 6.1)
 
 GEM

--- a/lib/zombie_record/restorable.rb
+++ b/lib/zombie_record/restorable.rb
@@ -13,7 +13,7 @@ module ZombieRecord
     # Returns nothing.
     def restore!
       if frozen?
-        raise "cannot restore an object that has been destroyed directly; " <<
+        raise "cannot restore an object that has been destroyed directly; " \
               "please make sure to load it from the database again."
       end
 
@@ -96,8 +96,9 @@ module ZombieRecord
         delegate_to_record(name) { @record.public_send(name, ...) }
       end
 
-      # We want *all* methods to be delegated.
-      BasicObject.instance_methods.each do |name|
+      # We want *almost all* methods to be delegated.
+      delegated_methods = BasicObject.instance_methods - [:__send__, :__id__]
+      delegated_methods.each do |name|
         define_method(name) do |*args, &block|
           @record.public_send(name, *args, &block)
         end

--- a/lib/zombie_record/version.rb
+++ b/lib/zombie_record/version.rb
@@ -1,3 +1,3 @@
 module ZombieRecord
-  VERSION = "1.8.0"
+  VERSION = "1.9.0"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,8 @@ require 'active_record'
 require 'timecop'
 require 'byebug'
 
+Warning[:deprecated] = true
+
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'zombie_record'
 


### PR DESCRIPTION
This commit enables warnings when testing, and fixes the existing warnings. Notably, we will no longer delegate the methods `:__id__` and `:__send__` to the deleted record object.

Before this change, with deprecation warnings enabled, we would see e.g.
```
lib/zombie_record/restorable.rb:101: warning: redefining '__send__' may cause serious problems
lib/zombie_record/restorable.rb:101: warning: redefining '__id__' may cause serious problems
```